### PR TITLE
Update ocapld to 1.6.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-async-handler": "^1.1.4",
     "http-signature-zcap-verify": "^1.0.0",
     "jsonld-signatures": "^4.1.1",
-    "ocapld": "^1.3.0"
+    "ocapld": "^1.6.1"
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",


### PR DESCRIPTION
This upgrades ocapld for this project so a mismatched `expectedRootCapaility` throws as it should. The rest of the fix for the current issues will come later.

p.s.

  31 passing (2s)
  7 pending

for the tests after the change