### PR TITLE
Get root for invocation target

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -751,66 +751,46 @@ async function _generateRootCapability(url) {
 }
 
 /**
- * Gets the expectedRootCapability for a zCap from the invocationTarget.
- *
- * @param {object} Options to use.
- * @param {string|Array<string>} options.invocationTarget - The
- *   invocationTarget.
- * @param {string} options.edvId - The edvId.
- * @param {string} [options.docPath] - An optional docPath.
- *
- * @return {string|Array<string>} The expectedRootCapability for
- *   the invocationTarget.
+* Gets an `expectedRootCapability` from an `invocationTarget`. This function
+* handles special cases where the `invocationTarget` does not match the
+* `expectedRootCapability` because the `invocationTarget` cannot be expressed
+* as a zcap.
+*
+* @param {object} options - Options to use.
+* @param {string} options.invocationTarget - An invocationTarget.
+* @param {string} options.edvId - The edvId (URL to the EDV).
+*
+* @return {string | Array<string>} The `expectedRootCapability` for
+*   the `invocationTarget`.
  */
-function _getExpectedRootCapability({invocationTarget = '', edvId, docPath}) {
-  const verifyDocPath = url =>
-    url.includes('documents') && !url.endsWith('documents');
-  if(typeof invocationTarget === 'string') {
-    // this handles calls on the authorizations api
-    if(invocationTarget.endsWith('authorizations')) {
-      return `${edvId}/zcaps/authorizations`;
-    }
-    // this handles calls on the documents api
-    if(invocationTarget.endsWith('documents')) {
-      return `${edvId}/zcaps/documents`;
-    }
-    // chunks and documents by id have the same rootCap
-    if(verifyDocPath(invocationTarget)) {
-      return [
-        `${edvId}/zcaps${docPath}`,
-        `${edvId}/zcaps/documents`
-      ];
-    }
+function _getExpectedRootCapability({invocationTarget, edvId}) {
+  // `authorizations` endpoint cannot be expressed as a zcap, map to zcap space
+  if(invocationTarget === `${edvId}/authorizations`) {
+    return `${edvId}/zcaps/authorizations`;
   }
-  if(Array.isArray(invocationTarget)) {
-    const queryCount = invocationTarget.filter(
-      url => url.includes('query')).length;
-    const docCount = invocationTarget.filter(
-      url => url.includes('documents')).length;
-    // if a url ends in query and another in documents
-    // then return the rootCaps for query and documents
-    // this handles calls on query api
-    if((queryCount === 1) && (docCount === 1)) {
-      return [
-        `${edvId}/zcaps/query`,
-        `${edvId}/zcaps/documents`
-      ];
-    }
-    const docPathCount = invocationTarget.filter(
-      url => verifyDocPath(url)).length;
-    // the other case is one url ends in a docPath
-    // and one is a documents path.
-    // this handles calls on the chunk and documents api
-    if((docCount === 2) && (docPathCount === 1)) {
-      return [
-        `${edvId}/zcaps${docPath}`,
-        `${edvId}/zcaps/documents`
-      ];
-    }
+  // `documents` endpoint cannot be expressed as a zcap, map to zcap space
+  if(invocationTarget === `${edvId}/documents`) {
+    return `${edvId}/zcaps/documents`;
   }
-  throw new BedrockError(
-    'Unknown invocationTarget',
-    'ConstraintError', {invocationTarget, public: true, httpStatusCode: 400});
+  // a specific document cannot be expressed as a zcap, map to zcap space
+  // and allow root zcap to be entire collection or just the document
+  if(invocationTarget.startsWith(`${edvId}/documents/`)) {
+    const docPath = invocationTarget.substr(`${edvId}/documents/`.length);
+    return [
+      `${edvId}/zcaps/documents/${docPath}`,
+      `${edvId}/zcaps/documents`
+    ];
+  }
+  // query endpoint can't be expressed as zcap, map to zcap space and allow
+  // documents endpoint as a root zcap for queries as well
+  if(invocationTarget === `${edvId}/query`) {
+    return [
+      `${edvId}/zcaps/query`,
+      `${edvId}/zcaps/documents`
+    ];
+  }
+  // otherwise use default behavior of `invocationTarget` matches root zcap
+  return invocationTarget;
 }
 
 function _getInvocationTarget(url) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -760,8 +760,7 @@ async function _generateRootCapability(url) {
 * @param {string} options.invocationTarget - An invocationTarget.
 * @param {string} options.edvId - The edvId (URL to the EDV).
 *
-* @return {string | Array<string>} The `expectedRootCapability` for
-*   the `invocationTarget`.
+* @return {string} The `expectedRootCapability` for the `invocationTarget`.
  */
 function _getExpectedRootCapability({invocationTarget, edvId}) {
   // `authorizations` endpoint cannot be expressed as a zcap, map to zcap space

--- a/lib/http.js
+++ b/lib/http.js
@@ -582,7 +582,7 @@ const DOCUMENT_LOADER = async url => {
   throw error;
 };
 
-async function _verifyDelegation({/*edvId, controller,*/capability}) {
+async function _verifyDelegation({capability, edvId}) {
   const invocationTarget = typeof capability.invocationTarget === 'string' ?
     capability.invocationTarget : capability.invocationTarget.id;
   const documentLoader = extendContextLoader(async url => {
@@ -617,10 +617,12 @@ async function _verifyDelegation({/*edvId, controller,*/capability}) {
 
     return DOCUMENT_LOADER(url);
   });
-
+  const expectedRootCapability = _getExpectedRootCapability(
+    {invocationTarget, edvId});
   const {verified, error} = await jsigs.verify(capability, {
     suite: new Ed25519Signature2018(),
     purpose: new CapabilityDelegation({
+      expectedRootCapability,
       suite: new Ed25519Signature2018()
     }),
     documentLoader,
@@ -746,6 +748,69 @@ async function _generateRootCapability(url) {
     invoker: config.invoker,
     delegator: config.delegator
   };
+}
+
+/**
+ * Gets the expectedRootCapability for a zCap from the invocationTarget.
+ *
+ * @param {object} Options to use.
+ * @param {string|Array<string>} options.invocationTarget - The
+ *   invocationTarget.
+ * @param {string} options.edvId - The edvId.
+ * @param {string} [options.docPath] - An optional docPath.
+ *
+ * @return {string|Array<string>} The expectedRootCapability for
+ *   the invocationTarget.
+ */
+function _getExpectedRootCapability({invocationTarget = '', edvId, docPath}) {
+  const verifyDocPath = url =>
+    url.includes('documents') && !url.endsWith('documents');
+  if(typeof invocationTarget === 'string') {
+    // this handles calls on the authorizations api
+    if(invocationTarget.endsWith('authorizations')) {
+      return `${edvId}/zcaps/authorizations`;
+    }
+    // this handles calls on the documents api
+    if(invocationTarget.endsWith('documents')) {
+      return `${edvId}/zcaps/documents`;
+    }
+    // chunks and documents by id have the same rootCap
+    if(verifyDocPath(invocationTarget)) {
+      return [
+        `${edvId}/zcaps${docPath}`,
+        `${edvId}/zcaps/documents`
+      ];
+    }
+  }
+  if(Array.isArray(invocationTarget)) {
+    const queryCount = invocationTarget.filter(
+      url => url.includes('query')).length;
+    const docCount = invocationTarget.filter(
+      url => url.includes('documents')).length;
+    // if a url ends in query and another in documents
+    // then return the rootCaps for query and documents
+    // this handles calls on query api
+    if((queryCount === 1) && (docCount === 1)) {
+      return [
+        `${edvId}/zcaps/query`,
+        `${edvId}/zcaps/documents`
+      ];
+    }
+    const docPathCount = invocationTarget.filter(
+      url => verifyDocPath(url)).length;
+    // the other case is one url ends in a docPath
+    // and one is a documents path.
+    // this handles calls on the chunk and documents api
+    if((docCount === 2) && (docPathCount === 1)) {
+      return [
+        `${edvId}/zcaps${docPath}`,
+        `${edvId}/zcaps/documents`
+      ];
+    }
+  }
+  throw new BedrockError(
+    'Unknown invocationTarget',
+    'ConstraintError', {invocationTarget, public: true, httpStatusCode: 400});
 }
 
 function _getInvocationTarget(url) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-async-handler": "^1.1.4",
     "http-signature-zcap-verify": "^1.0.0",
     "jsonld-signatures": "^4.1.1",
-    "ocapld": "^1.3.0"
+    "ocapld": "^1.6.1"
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",


### PR DESCRIPTION
Adds a function that takes an `invocationTarget` and returns a the `expectedRootCapability` for it.
This is only used in the `_verifyDelegation` function which is used by `routes.authorizations`.

I can replace all `expectedRootCapability` calls with this if wanted, but it seems like overkill.

So let me know.

Also controller is being passed to `_verifyDelegation`, but is not used and is not an object apparently.