### PR TITLE
Use allowHierarchicalDelegation flag for zcap verification.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -62,7 +62,8 @@ exports.authorize = async ({
     expectedTarget, expectedRootCapability, expectedAction,
     inspectCapabilityChain: exports.inspectCapabilityChain,
     // TODO: support RsaSignature2018 and other suites?
-    suite: [new Ed25519Signature2018()]
+    suite: [new Ed25519Signature2018()],
+    allowHierarchicalDelegation: true,
   });
   if(!result.verified) {
     throw new BedrockError(


### PR DESCRIPTION
Depends on forthcoming PR in `http-signature-zcap-verify`

EDIT: https://github.com/digitalbazaar/http-signature-zcap-verify/pull/14