### PR TITLE
Issue 30 large sequence numbers

### DIFF
--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -83,8 +83,30 @@ describe('insert API', () => {
       });
       record.doc.should.eql(doc);
     });
-
   }
+  it('should fail to insert a document with a negative sequence number',
+    async () => {
+      let record, error = null;
+      try {
+        const actor = actors['alpha@example.com'];
+        const {doc1} = mockData;
+        const doc = {...doc1};
+        doc.id = await helpers.generateRandom();
+        doc.sequence = -1;
+        record = await brEdvStorage.insert({
+          actor,
+          edvId: mockEdvId,
+          doc,
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(record);
+      should.exist(error);
+      error.name.should.equal('TypeError');
+      error.message.should.equal(
+        '"doc.sequence" must be a non-negative integer.');
+    });
   it('should insert a document with an attribute', async () => {
     const actor = actors['alpha@example.com'];
     const {docWithAttributes: doc} = mockData;

--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -46,6 +46,28 @@ describe('insert API', () => {
     });
     record.doc.should.eql(doc);
   });
+  it('should insert a document with a large sequence', async () => {
+    const actor = actors['alpha@example.com'];
+    const {doc1} = mockData;
+    const doc = {...doc1};
+    doc.id = await helpers.generateRandom();
+    doc.sequence = helpers.largeNumber();
+    const hashedDocId = database.hash(doc.id);
+    let record = await brEdvStorage.insert({
+      actor,
+      edvId: mockEdvId,
+      doc,
+    });
+    should.exist(record);
+    record.edvId.should.equal(hashedMockEdvId);
+    record.id.should.equal(hashedDocId);
+    record.doc.should.eql(doc);
+    record = await database.collections.edvDoc.findOne({
+      edvId: hashedMockEdvId,
+      id: hashedDocId
+    });
+    record.doc.should.eql(doc);
+  });
   it('should insert a document with an attribute', async () => {
     const actor = actors['alpha@example.com'];
     const {docWithAttributes: doc} = mockData;

--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -47,7 +47,8 @@ describe('insert API', () => {
     record.doc.should.eql(doc);
   });
 
-  for(const test of helpers.largeNumbers) {
+  // test various sequence numbers
+  for(const test of helpers.sequenceNumberTests) {
     it(test.title, async () => {
       const actor = actors['alpha@example.com'];
       const {doc1} = mockData;

--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -47,20 +47,7 @@ describe('insert API', () => {
     record.doc.should.eql(doc);
   });
 
-  const largeNumbers = [{
-    title: 'should insert a document with max 32-Bit sequence number',
-    sequence: Math.pow(2, 31) - 1
-  }, {
-    title: 'should insert a document with the minimum 64-Bit sequence number',
-    sequence: Math.pow(2, 32)
-  }, {
-    title: 'should insert a document with a random 64-Bit sequence number',
-    sequence: helpers.largeNumber()
-  }, {
-    title: 'should insert a document with MAX_SAFE_INTEGER as sequence number',
-    sequence: Number.MAX_SAFE_INTEGER
-  }];
-  for(const test of largeNumbers) {
+  for(const test of helpers.largeNumbers) {
     it(test.title, async () => {
       const actor = actors['alpha@example.com'];
       const {doc1} = mockData;

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -31,7 +31,10 @@ exports.KMS_MODULE = 'ssm-v1';
 // algorithm required for the jwe headers
 exports.JWE_ALG = 'ECDH-ES+A256KW';
 
-const largeRange = Number.MAX_SAFE_INTEGER - Math.pow(2, 32);
+const min64Bit = Math.pow(2, 32);
+const largeRange = Number.MAX_SAFE_INTEGER - min64Bit;
+// this should get the middle 64 bit sequence number
+const middle64Bit = Math.ceil(largeRange / 2) + min64Bit;
 
 // gets a number between MAX_SAFE_INTEGER & 2^32.
 exports.largeNumber = () => {
@@ -39,6 +42,22 @@ exports.largeNumber = () => {
   return Number.MAX_SAFE_INTEGER - Math.floor(largeRange * Math.random());
 };
 
+exports.largeNumbers = [{
+  title: 'should insert a document with max 32-Bit sequence number',
+  sequence: Math.pow(2, 31) - 1
+}, {
+  title: 'should insert a document with the minimum 64-Bit sequence number',
+  sequence: min64Bit
+}, {
+  title: 'should insert a document with the middle 64-bit sequence number',
+  sequence: middle64Bit
+}, {
+  title: 'should insert a document with a random 64-Bit sequence number',
+  sequence: exports.largeNumber()
+}, {
+  title: 'should insert a document with MAX_SAFE_INTEGER as sequence number',
+  sequence: Number.MAX_SAFE_INTEGER
+}];
 exports.generateRandom = async () => {
   // 128-bit random number, multibase encoded
   // 0x00 = identity tag, 0x10 = length (16 bytes)

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -53,16 +53,16 @@ exports.sequenceNumberTests = [
   ['2**32-1', 2 ** 32 - 1],
   ['2**32', 2 ** 32],
   ['2**32+1', 2 ** 32 + 1],
-  // betwixt UINT32_MAX and Number.MAX_SAFE_INTEGER
-  ['middle betwixt 2**32-1 and MAX_SAFE_INTEGER',
-    (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
-  ['random betwixt 2**32-1 and MAX_SAFE_INTEGER',
+  // in range [UINT32_MAX + 1, Number.MAX_SAFE_INTEGER]
+  ['in range [2**32, MAX_SAFE_INTEGER] (middle)',
+    2 ** 32 + (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
+  ['in range [2**32, MAX_SAFE_INTEGER] (random)',
     getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
   // near Number.MAX_SAFE_INTEGER
   ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
   ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
 ].map(d => ({
-  title: `should insert a document with sequence number of ${d[0]}`,
+  title: `should insert a document with sequence number ${d[0]}`,
   sequence: d[1]
 }));
 

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -27,6 +27,14 @@ exports.KMS_MODULE = 'ssm-v1';
 // algorithm required for the jwe headers
 exports.JWE_ALG = 'ECDH-ES+A256KW';
 
+const largeRange = Number.MAX_SAFE_INTEGER - Math.pow(2, 32);
+
+// gets a number between MAX_SAFE_INTEGER & 2^32.
+exports.largeNumber = () => {
+  // if Math.random is 1 the number will be 2^32 otherwise it will be larger.
+  return Number.MAX_SAFE_INTEGER - Math.floor(largeRange * Math.random());
+};
+
 exports.makeDelegationTesters = async ({testers = [], mockData}) => {
   const actors = await exports.getActors(mockData);
   const accounts = mockData.accounts;

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -46,18 +46,18 @@ exports.sequenceNumberTests = [
   ['0', 0],
   ['1', 1],
   // near INT32_MAX
-  ['2**31-1', Math.pow(2, 31) - 1],
-  ['2**31', Math.pow(2, 31)],
-  ['2**31+1', Math.pow(2, 31) + 1],
+  ['2**31-1', 2 ** 31 - 1],
+  ['2**31', 2 ** 31],
+  ['2**31+1', 2 ** 31 + 1],
   // near UINT32_MAX
-  ['2**32-1', Math.pow(2, 32) - 1],
-  ['2**32', Math.pow(2, 32)],
-  ['2**32+1', Math.pow(2, 32) + 1],
+  ['2**32-1', 2 ** 32 - 1],
+  ['2**32', 2 ** 32],
+  ['2**32+1', 2 ** 32 + 1],
   // betwixt UINT32_MAX and Number.MAX_SAFE_INTEGER
   ['middle betwixt 2**32-1 and MAX_SAFE_INTEGER',
-    (Number.MAX_SAFE_INTEGER - Math.pow(2, 32) - 1) / 2],
-  ['random betwixt 2**31-1 and MAX_SAFE_INTEGER',
-    getRandomIntInclusive(Math.pow(2, 32), Number.MAX_SAFE_INTEGER)],
+    (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
+  ['random betwixt 2**32-1 and MAX_SAFE_INTEGER',
+    getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
   // near Number.MAX_SAFE_INTEGER
   ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
   ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],


### PR DESCRIPTION
Addresses: https://github.com/digitalbazaar/bedrock-edv-storage/issues/30

Adds tests for

```
should insert a document with sequence number of 0
should insert a document with sequence number of 1
should insert a document with sequence number of 2**31-1
should insert a document with sequence number of 2**31
should insert a document with sequence number of 2**31+1
should insert a document with sequence number of 2**32-1
should insert a document with sequence number of 2**32
should insert a document with sequence number of 2**32+1
should insert a document with sequence number of middle betwixt 2**32-1 and MAX_SAFE_INTEGER
should insert a document with sequence number of random betwixt 2**31-1 and MAX_SAFE_INTEGER
should insert a document with sequence number of MAX_SAFE_INTEGER-1
should insert a document with sequence number of MAX_SAFE_INTEGER
should fail to insert a document with a negative sequence number
```

