### PR TITLE
Update sequence number test generation.

### DIFF
--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -47,7 +47,8 @@ describe('insert API', () => {
     record.doc.should.eql(doc);
   });
 
-  for(const test of helpers.largeNumbers) {
+  // test various sequence numbers
+  for(const test of helpers.sequenceNumberTests) {
     it(test.title, async () => {
       const actor = actors['alpha@example.com'];
       const {doc1} = mockData;


### PR DESCRIPTION
- Remove naming of numbers and just use them.
- Compact the test generation so it's easier to add tests.
- Test values around edge cases like 0, INT32_MAX, UINT32_MAX, and MAX_SAFE_INTEGER.
- Add the large middle and large random tests even though the above tests are likely sufficient.