### PR TITLE
Issue 33 add sequence tests for edv-client

### DIFF
--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -95,6 +95,31 @@ describe('insert API', () => {
       error.message.should.equal(
         '"doc.sequence" must be a non-negative integer.');
     });
+
+  it('should fail to insert a document with' +
+    'a sequence number greater than MAX_SAFE_INTEGER',
+  async () => {
+    let record, error = null;
+    try {
+      const actor = actors['alpha@example.com'];
+      const {doc1} = mockData;
+      const doc = {...doc1};
+      doc.id = await helpers.generateRandom();
+      doc.sequence = Number.MAX_SAFE_INTEGER + 1;
+      record = await brEdvStorage.insert({
+        actor,
+        edvId: mockEdvId,
+        doc,
+      });
+    } catch(e) {
+      error = e;
+    }
+    should.not.exist(record);
+    should.exist(error);
+    error.name.should.equal('TypeError');
+    error.message.should.equal(
+      '"doc.sequence" must be less than MAX_SAFE_INTEGER');
+  });
   it('should insert a document with an attribute', async () => {
     const actor = actors['alpha@example.com'];
     const {docWithAttributes: doc} = mockData;

--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -48,7 +48,7 @@ describe('insert API', () => {
   });
 
   // test various sequence numbers
-  for(const test of helpers.sequenceNumberTests) {
+  for(const test of helpers.sequenceNumberTests({})) {
     it(test.title, async () => {
       const actor = actors['alpha@example.com'];
       const {doc1} = mockData;

--- a/test/mocha/12-insert.js
+++ b/test/mocha/12-insert.js
@@ -96,7 +96,7 @@ describe('insert API', () => {
         '"doc.sequence" must be a non-negative integer.');
     });
 
-  it('should fail to insert a document with' +
+  it('should fail to insert a document with ' +
     'a sequence number greater than MAX_SAFE_INTEGER',
   async () => {
     let record, error = null;

--- a/test/mocha/27-http-edv-client.js
+++ b/test/mocha/27-http-edv-client.js
@@ -136,7 +136,7 @@ describe('bedrock-edv-storage HTTP API - edv-client', () => {
         should.exist(error);
         error.name.should.equal('Error');
         error.message.should.equal(
-          `"doc.sequence" must be less than MAX_SAFE_INTEGER`
+          '"doc.sequence" must be less than MAX_SAFE_INTEGER'
         );
       });
   });

--- a/test/mocha/27-http-edv-client.js
+++ b/test/mocha/27-http-edv-client.js
@@ -1,0 +1,109 @@
+/*!
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+require('bedrock-edv-storage');
+const bedrock = require('bedrock');
+const brEdvStorage = require('bedrock-edv-storage');
+const {util: {clone}} = bedrock;
+const {config} = bedrock;
+const helpers = require('./helpers');
+const assertions = require('./assertions');
+const mockData = require('./mock.data');
+const {CapabilityAgent} = require('webkms-client');
+let actors;
+let urls;
+
+describe('bedrock-edv-storage HTTP API - edv-client', () => {
+  let passportStub;
+
+  before(async () => {
+    await helpers.prepareDatabase(mockData);
+    actors = await helpers.getActors(mockData);
+    // common URLs
+    const {baseUri} = config.server;
+    const root = `${baseUri}/edvs`;
+    const invalid = `${baseUri}/edvs/invalid`;
+    urls = {
+      edvs: root,
+      invalidDocuments: `${invalid}/documents`,
+      invalidQuery: `${invalid}/query`
+    };
+  });
+
+  before(() => {
+    passportStub = helpers.stubPassport({actor: actors['alpha@example.com']});
+  });
+
+  after(() => {
+    passportStub.restore();
+  });
+
+  describe.only('update API', () => {
+    let capabilityAgent;
+    let edvClient;
+    let accounts;
+    const mockEdvId = `${config.server.baseUri}/edvs/z19xXoFRcobgskDQ6ywrRaa12`;
+    before(async () => {
+      await helpers.prepareDatabase(mockData);
+      actors = await helpers.getActors(mockData);
+      accounts = mockData.accounts;
+    });
+    before(async () => {
+      const actor = actors['alpha@example.com'];
+      const account = accounts['alpha@example.com'].account;
+      const edvConfig = {...mockData.config, controller: account.id};
+      edvConfig.id = mockEdvId;
+      await brEdvStorage.insertConfig({actor, config: edvConfig});
+    });
+    before(async () => {
+      const secret = 'e4f2f31d-b21a-427e-b49a-b4447d5bb219';
+      const handle = 'testKey4';
+      capabilityAgent = await CapabilityAgent.fromSecret(
+        {secret, handle});
+
+      const keystoreAgent = await helpers.createKeystore({capabilityAgent});
+
+      // corresponds to the passport authenticated user
+      const actor = actors['alpha@example.com'];
+
+      ({edvClient} = await helpers.createEdv(
+        {actor, capabilityAgent, keystoreAgent, urls}));
+    });
+
+    for(const test of helpers.updateSequenceNumbers({update: true})) {
+      it(test.title, async () => {
+        let result;
+        let err;
+        const actor = actors['alpha@example.com'];
+        const doc = clone(mockData.docWithNoIndexedOrRecipients);
+        doc.id = await helpers.generateRandom();
+        doc.sequence = test.sequence;
+        doc.content = {
+          foo: 'bar'
+        };
+        const record = await brEdvStorage.insert({
+          actor,
+          edvId: mockEdvId,
+          doc,
+        });
+        should.exist(record);
+        record.doc.content.apples = test.sequence;
+        try {
+          result = await edvClient.update({
+            doc: record.doc,
+            invocationSigner: capabilityAgent.getSigner()
+          });
+        } catch(e) {
+          err = e;
+        }
+        should.exist(result);
+        assertNoError(err);
+        assertions.shouldBeEdvDocument({doc: result});
+        result.sequence.should.equal(test.sequence + 1);
+        result.content.should.eql(record.doc.content);
+      });
+    }
+  });
+});

--- a/test/mocha/27-http-edv-client.js
+++ b/test/mocha/27-http-edv-client.js
@@ -40,7 +40,7 @@ describe('bedrock-edv-storage HTTP API - edv-client', () => {
     passportStub.restore();
   });
 
-  describe.only('update API', () => {
+  describe('update API', () => {
     let capabilityAgent;
     let edvClient;
     let accounts;
@@ -72,7 +72,7 @@ describe('bedrock-edv-storage HTTP API - edv-client', () => {
         {actor, capabilityAgent, keystoreAgent, urls}));
     });
 
-    for(const test of helpers.updateSequenceNumbers({update: true})) {
+    for(const test of helpers.sequenceNumberTests({update: true})) {
       it(test.title, async () => {
         let result;
         let err;

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -41,34 +41,35 @@ function getRandomIntInclusive(min, max) {
 }
 
 // test various sequence numbers at edge case zones
-exports.sequenceNumberTests = [
-  // low values
-  ['0', 0],
-  ['1', 1],
-  // near INT32_MAX
-  ['2**31-1', 2 ** 31 - 1],
-  ['2**31', 2 ** 31],
-  ['2**31+1', 2 ** 31 + 1],
-  // near UINT32_MAX
-  ['2**32-1', 2 ** 32 - 1],
-  ['2**32', 2 ** 32],
-  ['2**32+1', 2 ** 32 + 1],
-  // in range [UINT32_MAX + 1, Number.MAX_SAFE_INTEGER]
-  ['in range [2**32, MAX_SAFE_INTEGER] (middle)',
-    2 ** 32 + (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
-  ['in range [2**32, MAX_SAFE_INTEGER] (random)',
-    getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
-  // near Number.MAX_SAFE_INTEGER
-  ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
-  ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
-].map(d => ({
-  title: `should insert a document with sequence number ${d[0]}`,
-  sequence: d[1]
-}));
+// exports.sequenceNumberTests = [
+//   // low values
+//   ['0', 0],
+//   ['1', 1],
+//   // near INT32_MAX
+//   ['2**31-1', 2 ** 31 - 1],
+//   ['2**31', 2 ** 31],
+//   ['2**31+1', 2 ** 31 + 1],
+//   // near UINT32_MAX
+//   ['2**32-1', 2 ** 32 - 1],
+//   ['2**32', 2 ** 32],
+//   ['2**32+1', 2 ** 32 + 1],
+//   // in range [UINT32_MAX + 1, Number.MAX_SAFE_INTEGER]
+//   ['in range [2**32, MAX_SAFE_INTEGER] (middle)',
+//     2 ** 32 + (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
+//   ['in range [2**32, MAX_SAFE_INTEGER] (random)',
+//     getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
+//   // near Number.MAX_SAFE_INTEGER
+//   ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
+//   ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
+// ].map(d => ({
+//   title: `should insert a document with sequence number ${d[0]}`,
+//   sequence: d[1]
+// }));
 
-exports.updateSequenceNumbers = ({update = false}) => {
+exports.sequenceNumberTests = ({update = false}) => {
   const up = 'update';
   const ins = 'insert';
+  const message = `should ${update ? up : ins} a document with sequence number`;
   return [
     // low values
     ['1', 1],
@@ -89,8 +90,7 @@ exports.updateSequenceNumbers = ({update = false}) => {
     ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
     ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
   ].map(d => ({
-    title: `should ${update ? up : ins} \
-     a document with sequence number ${d[0]}`,
+    title: `${message} ${d[0]}`,
     sequence: d[1]
   }));
 };
@@ -205,7 +205,6 @@ exports.createKeystore = async ({capabilityAgent, referenceId}) => {
     config.referenceId = referenceId;
   }
   const kmsBaseUrl = `${bedrock.config.server.baseUri}/kms`;
-  console.log('kmsBaseUrl', kmsBaseUrl);
   const {httpsAgent} = brHttpsAgent;
   const keystore = await KmsClient.createKeystore({
     url: `${kmsBaseUrl}/keystores`,

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -43,9 +43,8 @@ function getRandomIntInclusive(min, max) {
 // test various sequence numbers at edge case zones
 
 exports.sequenceNumberTests = ({update = false}) => {
-  const up = 'update';
-  const ins = 'insert';
-  const message = `should ${update ? up : ins} a document with sequence number`;
+  const message = `should ${update ? 'update' : 'insert'}` +
+  `a document with sequence number`;
   const valueArray = [
     // low values
     ['1', 1],

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -41,36 +41,12 @@ function getRandomIntInclusive(min, max) {
 }
 
 // test various sequence numbers at edge case zones
-// exports.sequenceNumberTests = [
-//   // low values
-//   ['0', 0],
-//   ['1', 1],
-//   // near INT32_MAX
-//   ['2**31-1', 2 ** 31 - 1],
-//   ['2**31', 2 ** 31],
-//   ['2**31+1', 2 ** 31 + 1],
-//   // near UINT32_MAX
-//   ['2**32-1', 2 ** 32 - 1],
-//   ['2**32', 2 ** 32],
-//   ['2**32+1', 2 ** 32 + 1],
-//   // in range [UINT32_MAX + 1, Number.MAX_SAFE_INTEGER]
-//   ['in range [2**32, MAX_SAFE_INTEGER] (middle)',
-//     2 ** 32 + (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
-//   ['in range [2**32, MAX_SAFE_INTEGER] (random)',
-//     getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
-//   // near Number.MAX_SAFE_INTEGER
-//   ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
-//   ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
-// ].map(d => ({
-//   title: `should insert a document with sequence number ${d[0]}`,
-//   sequence: d[1]
-// }));
 
 exports.sequenceNumberTests = ({update = false}) => {
   const up = 'update';
   const ins = 'insert';
   const message = `should ${update ? up : ins} a document with sequence number`;
-  return [
+  const valueArray = [
     // low values
     ['1', 1],
     // near INT32_MAX
@@ -88,8 +64,13 @@ exports.sequenceNumberTests = ({update = false}) => {
       getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
     // near Number.MAX_SAFE_INTEGER
     ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
-    ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
-  ].map(d => ({
+    ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER]];
+
+  // If we testing insert, add a zero value entry
+  if(!update) {
+    valueArray.unshift(['0', 0]);
+  }
+  return valueArray.map(d => ({
     title: `${message} ${d[0]}`,
     sequence: d[1]
   }));

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -66,6 +66,35 @@ exports.sequenceNumberTests = [
   sequence: d[1]
 }));
 
+exports.updateSequenceNumbers = ({update = false}) => {
+  const up = 'update';
+  const ins = 'insert';
+  return [
+    // low values
+    ['1', 1],
+    // near INT32_MAX
+    ['2**31-1', 2 ** 31 - 1],
+    ['2**31', 2 ** 31],
+    ['2**31+1', 2 ** 31 + 1],
+    // near UINT32_MAX
+    ['2**32-1', 2 ** 32 - 1],
+    ['2**32', 2 ** 32],
+    ['2**32+1', 2 ** 32 + 1],
+    // in range [UINT32_MAX + 1, Number.MAX_SAFE_INTEGER]
+    ['in range [2**32, MAX_SAFE_INTEGER] (middle)',
+      2 ** 32 + (Number.MAX_SAFE_INTEGER - 2 ** 32 - 1) / 2],
+    ['in range [2**32, MAX_SAFE_INTEGER] (random)',
+      getRandomIntInclusive(2 ** 32, Number.MAX_SAFE_INTEGER)],
+    // near Number.MAX_SAFE_INTEGER
+    ['MAX_SAFE_INTEGER-1', Number.MAX_SAFE_INTEGER - 1],
+    ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER],
+  ].map(d => ({
+    title: `should ${update ? up : ins} \
+     a document with sequence number ${d[0]}`,
+    sequence: d[1]
+  }));
+};
+
 exports.generateRandom = async () => {
   // 128-bit random number, multibase encoded
   // 0x00 = identity tag, 0x10 = length (16 bytes)
@@ -176,6 +205,7 @@ exports.createKeystore = async ({capabilityAgent, referenceId}) => {
     config.referenceId = referenceId;
   }
   const kmsBaseUrl = `${bedrock.config.server.baseUri}/kms`;
+  console.log('kmsBaseUrl', kmsBaseUrl);
   const {httpsAgent} = brHttpsAgent;
   const keystore = await KmsClient.createKeystore({
     url: `${kmsBaseUrl}/keystores`,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -118,7 +118,7 @@ data.doc2 = {
   }
 };
 
-// NOTE: There are no keys in indexed or receipients by design
+// NOTE: There are no keys in indexed or recipients by design
 data.docWithNoIndexedOrRecipients = {
   "id": "z19pjdSMQMkBqqJ5zsaagncfU",
   "sequence": 0,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -118,6 +118,22 @@ data.doc2 = {
   }
 };
 
+// NOTE: There are no keys in indexed or receipients by design
+data.docWithNoIndexedOrRecipients = {
+  "id": "z19pjdSMQMkBqqJ5zsaagncfU",
+  "sequence": 0,
+  "indexed": [
+  ],
+  "jwe": {
+    "protected": "eyJlbmMiOiJDMjBQIn0",
+    "recipients": [
+    ],
+    "iv": "S-bNe9DayHcXWhBH",
+    "ciphertext": "bcZnPyreRmcLCngVbMHJTNeIIxkSJno",
+    "tag": "R2xDL9AJo7IhZ7y_sebgJw"
+  }
+};
+
 data.docWithAttributes = {
   "id": "z19pjdSMQMkBqqJ5zsbbgbbbb",
   "sequence": 0,


### PR DESCRIPTION
Addresses #33 
These changes will add tests for:

- Node insert API
  - Testing if a sequence number larger than `Number.MAX_SAFE_INTEGER` can be inserted
- EDV update API
  - Testing if a sequence number is incremented successfully on update
  - Testing if an error is thrown if an incremented sequence number is greater than `Number.MAX_SAFE_INTEGER`

Additionally these changes refactor the `sequenceNumberTest` exported variable so that the proper range of values can be used if one is inserting values versus updating values