### PR TITLE
Unset `uniqueAttributes` if cleared in a doc update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-edv-storage ChangeLog
 
+## 9.0.1 - 2021-06-xx
+
+### Fixed
+- Unset `uniqueAttributes` if cleared in a document update.
+
 ## 9.0.0 - 2021-05-21
 
 ### Changed

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -403,9 +403,12 @@ api.update = async ({edvId, doc}) => {
 
   // build top-level unique index field
   const $set = {doc, 'meta.updated': now};
+  const $unset = {};
   const uniqueAttributes = _buildUniqueAttributesIndex(doc);
   if(uniqueAttributes.length > 0) {
     $set.uniqueAttributes = uniqueAttributes;
+  } else {
+    $unset.uniqueAttributes = true;
   }
 
   try {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -420,7 +420,8 @@ api.update = async ({edvId, doc}) => {
       $set,
       $setOnInsert: {
         edvId: record.edvId, id: record.id, 'meta.created': now
-      }
+      },
+      $unset
     }, {...database.writeOptions, upsert: true});
 
     if(result.result.n > 0) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -401,28 +401,29 @@ api.update = async ({edvId, doc}) => {
     doc
   };
 
+  // build update
+  const update = {};
+  update.$set = {doc, 'meta.updated': now};
+
   // build top-level unique index field
-  const $set = {doc, 'meta.updated': now};
-  const $unset = {};
   const uniqueAttributes = _buildUniqueAttributesIndex(doc);
   if(uniqueAttributes.length > 0) {
-    $set.uniqueAttributes = uniqueAttributes;
+    update.$set.uniqueAttributes = uniqueAttributes;
   } else {
-    $unset.uniqueAttributes = true;
+    update.$unset = {uniqueAttributes: true};
   }
+
+  // add insert-only fields
+  update.$setOnInsert = {
+    edvId: record.edvId, id: record.id, 'meta.created': now
+  };
 
   try {
     const result = await database.collections.edvDoc.updateOne({
       edvId: record.edvId,
       id: record.id,
       'doc.sequence': doc.sequence - 1
-    }, {
-      $set,
-      $setOnInsert: {
-        edvId: record.edvId, id: record.id, 'meta.created': now
-      },
-      $unset
-    }, {...database.writeOptions, upsert: true});
+    }, update, {...database.writeOptions, upsert: true});
 
     if(result.result.n > 0) {
       // document upserted or modified: success


### PR DESCRIPTION
No existing tests on unique attributes to copy those need to be added elsewhere.