### PR TITLE
Use offline-capable version of did-io/veres-one.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bedrock": "^4.1.1",
     "bedrock-account": "^5.0.0",
     "bedrock-did-context": "^2.0.0",
-    "bedrock-did-io": "^2.0.0",
+    "bedrock-did-io": "digitalbazaar/bedrock-did-io#offline-veres",
     "bedrock-express": "^4.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-mongodb": "^8.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -39,7 +39,7 @@
     "bedrock": "^4.1.1",
     "bedrock-account": "^5.0.0",
     "bedrock-did-context": "^2.0.0",
-    "bedrock-did-io": "^2.0.0",
+    "bedrock-did-io": "digitalbazaar/bedrock-did-io#offline-veres",
     "bedrock-edv-storage": "file:..",
     "bedrock-express": "^4.0.0",
     "bedrock-https-agent": "^2.0.0",


### PR DESCRIPTION
Allows downstream document resolvers to use `driver.getInitial()` instead of `.get()`, which allows fetching unregistered VeresOne DIDs in offline mode.