### PR TITLE
Drops support for Nodejs <= 16 and updates peer dep to `@bedrock/did-io@10.1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -24,14 +24,14 @@ jobs:
     timeout-minutes: 10
     services:
       mongodb:
-        image: mongo:4.4
+        image: mongo:5
         ports:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -50,16 +50,16 @@ jobs:
     timeout-minutes: 10
     services:
       mongodb:
-        image: mongo:4.4
+        image: mongo:5
         ports:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
@@ -71,7 +71,7 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-edv-storage ChangeLog
 
+## 17.0.0 - 2023-08-TBD
+
+### Changed
+- **BREAKING**: Drop support for Node.js <= 16.
+- **BREAKING**: Update `@bedrock/did-io` peer dependency to v10.1.
+
 ## 16.2.4 - 2022-12-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "eslint": "^8.18.0",
-    "eslint-config-digitalbazaar": "^4.0.1",
-    "eslint-plugin-jsdoc": "^39.3.3",
-    "eslint-plugin-unicorn": "^43.0.0",
-    "jsdoc-to-markdown": "^7.1.1"
+    "eslint": "^8.48.0",
+    "eslint-config-digitalbazaar": "^5.0.1",
+    "eslint-plugin-jsdoc": "^46.5.0",
+    "eslint-plugin-unicorn": "^48.0.1",
+    "jsdoc-to-markdown": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lib": "./lib"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "devDependencies": {
     "eslint": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@bedrock/app-identity": "^4.0.0",
     "@bedrock/core": "^6.0.1",
     "@bedrock/did-context": "^4.0.0",
-    "@bedrock/did-io": "^9.0.1",
+    "@bedrock/did-io": "^10.1.0",
     "@bedrock/express": "^8.0.0",
     "@bedrock/jsonld-document-loader": "^3.0.0",
     "@bedrock/meter-usage-reporter": "^8.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,7 @@
     "@bedrock/app-identity": "^4.0.0",
     "@bedrock/core": "^6.0.1",
     "@bedrock/did-context": "^4.0.0",
-    "@bedrock/did-io": "^9.0.1",
+    "@bedrock/did-io": "^10.1.0",
     "@bedrock/edv-storage": "file:..",
     "@bedrock/express": "^8.0.0",
     "@bedrock/https-agent": "^4.0.0",


### PR DESCRIPTION
The `@bedrock/did-io` peer dep needs to be updated to resolve dependency conflicts  during installation when `@bedrock/did-io` is updated to latest in `veres-vault` PR 11.